### PR TITLE
Set JvmName and add JvmOverloads for Java interop

### DIFF
--- a/src/main/kotlin/no/liflig/snapshot/Json.kt
+++ b/src/main/kotlin/no/liflig/snapshot/Json.kt
@@ -1,4 +1,4 @@
-@file:JvmName("JsonSnapshotUtils")
+@file:JvmName("JsonSnapshot")
 package no.liflig.snapshot
 
 import kotlinx.serialization.ExperimentalSerializationApi

--- a/src/main/kotlin/no/liflig/snapshot/Json.kt
+++ b/src/main/kotlin/no/liflig/snapshot/Json.kt
@@ -1,3 +1,4 @@
+@file:JvmName("JsonSnapshotUtils")
 package no.liflig.snapshot
 
 import kotlinx.serialization.ExperimentalSerializationApi

--- a/src/main/kotlin/no/liflig/snapshot/Json.kt
+++ b/src/main/kotlin/no/liflig/snapshot/Json.kt
@@ -20,6 +20,7 @@ private fun produceJsonErrors(previous: String, current: String): String {
 /**
  * Ensure that the serialized JSON matches an existing snapshot.
  */
+@JvmOverloads
 fun verifyJsonSnapshot(name: String, value: JsonElement, ignoredPaths: List<String>? = null) {
   val prettified = json.encodeToString(JsonElement.serializer(), value) + "\n"
   verifySnapshot(name, prettified, ::produceJsonErrors) { existingValue: String, newValue: String ->
@@ -31,6 +32,7 @@ fun verifyJsonSnapshot(name: String, value: JsonElement, ignoredPaths: List<Stri
  * Verify that the value matches the snapshot. The value must be a valid JSON string
  * and will be reformatted. Use [verifyStringSnapshot] to check for whitespace.
  */
+@JvmOverloads
 fun verifyJsonSnapshot(name: String, value: String, ignoredPaths: List<String>? = null) {
   verifyJsonSnapshot(name, json.parseToJsonElement(value), ignoredPaths)
 }

--- a/src/main/kotlin/no/liflig/snapshot/Snapshot.kt
+++ b/src/main/kotlin/no/liflig/snapshot/Snapshot.kt
@@ -1,4 +1,4 @@
-@file:JvmName("StringSnapshotUtils")
+@file:JvmName("StringSnapshot")
 package no.liflig.snapshot
 
 import com.github.difflib.DiffUtils

--- a/src/main/kotlin/no/liflig/snapshot/Snapshot.kt
+++ b/src/main/kotlin/no/liflig/snapshot/Snapshot.kt
@@ -1,3 +1,4 @@
+@file:JvmName("StringSnapshotUtils")
 package no.liflig.snapshot
 
 import com.github.difflib.DiffUtils
@@ -45,6 +46,7 @@ private fun createDiff(
  *
  * The [getExtra] parameter is for local library usage.
  */
+@JvmOverloads
 fun verifyStringSnapshot(
   name: String,
   value: String,


### PR DESCRIPTION
## What's changed
- Annotate `verifyJsonSnapshot` with  @JvmOverloads, as Java does not support default params.